### PR TITLE
feat: adding documentArray type for subdocuments array support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ yarn add ts-mongoose mongoose @types/mongoose
 ```
 
 ## The Problem
-When using mongoose and Typescript, you must define schemas and interfaces. Both definitions must be maintained separately and must match each other. It can be error-prone during development and cause overhead.
-
+When using mongoose and Typescript, you must define schemas and interfaces. Both definitions must be maintained separately and must match each other. It can be error-prone during development and cause overhead.  
+  
 `ts-mongoose` is a very lightweight library that allows you to create a mongoose schema and a typescript type from a common definition.  
 All types as created from 1-liner functions and does not depend on decorators❗️.
-
+  
 For example:  
 `Type.string()` returns `{type: String, required: true}`, which is the same definition required in the original mongoose library.
 
@@ -34,9 +34,9 @@ const AddressSchema = new Schema({
 });
 
 const PhoneSchema = new Schema({
-  phone: { type: number, required: true },
-  name: String,
-});
+  phoneNumber: { type: Schema.Types.Number, required: true },
+  name: String
+})
 
 const UserSchema = new Schema({
   title: { type: String, required: true },
@@ -92,11 +92,11 @@ const AddressSchema = createSchema({
   city: Type.string(),
   country: Type.optionalString(),
   zip: Type.optionalString(),
-});
+}, { _id: false });
 
 const PhoneSchema = createSchema({
-  phone: Type.number(),
-  name: Type.optionalString()
+  phoneNumber: Type.number(),
+  name: Type.optionalString(),
 });
 
 const UserSchema = createSchema({
@@ -116,7 +116,7 @@ const UserSchema = createSchema({
   m: Type.mixed(),
   otherId: Type.objectId(),
   address: Type.schema().of(AddressSchema),
-  phones: Type.documentsArray().of(PhoneSchema),
+  phones: Type.array().of(PhoneSchema),
 });
 
 const User = typedModel('User', UserSchema);
@@ -145,18 +145,30 @@ User.findById('123').then(user => {
   email: Type.string({unique: true, index: true})
 }
 ```
-- `schema`, `object`, `array`, `documentsArray` types have a method `of` where you must provide a child type
+- `schema`, `object`, `array` types have a method `of` where you must provide a child type
 ```ts
 {
   // same as {type: [String], required: true}
   tags: Type.array().of(Type.string())
 }
 ```
+- `schema.of(ExampleSchema)` has typical for Subdocument additional fields and methods. Setting `{ _id: false }` in SchemaOptions won't attach `_id` property in Subdocument
 ```ts
+const AddressSchema = createSchema({city: Type.string()}, { _id: false });
 {
-  // same as {type: [ChildSchema], required: true}
-  tags: Type.documentsArray().of(ChildSchema)
+  // same as {type: AddressSchema}
+  address: Type.schema().of(AddressSchema)
 }
+// address property has city property, other Subdocument methods and properties except '_id'
+```
+- `array.of(ExampleSchema)` will return DocumentArray instead of standard array
+```ts
+const PhoneSchema = createSchema({phoneNumber: Type.number()}, { _id: false });
+{
+  // same as {type: [PhoneSchema]}
+  phones: Type.schema().of(PhoneSchema)
+}
+// phones property has such methods as create(), id(), but also those typical for arrays like map(), filter() etc
 ```
 - `ref` is a special type for creating references
 ```ts

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ yarn add ts-mongoose mongoose @types/mongoose
 ```
 
 ## The Problem
-When using mongoose and Typescript, you must define schemas and interfaces. Both definitions must be maintained separately and must match each other. It can be error-prone during development and cause overhead.  
-  
+When using mongoose and Typescript, you must define schemas and interfaces. Both definitions must be maintained separately and must match each other. It can be error-prone during development and cause overhead.
+
 `ts-mongoose` is a very lightweight library that allows you to create a mongoose schema and a typescript type from a common definition.  
 All types as created from 1-liner functions and does not depend on decorators❗️.
-  
+
 For example:  
 `Type.string()` returns `{type: String, required: true}`, which is the same definition required in the original mongoose library.
 
@@ -31,6 +31,11 @@ const AddressSchema = new Schema({
   city: { type: String, required: true },
   country: String,
   zip: String,
+});
+
+const PhoneSchema = new Schema({
+  phone: { type: number, required: true },
+  name: String,
 });
 
 const UserSchema = new Schema({
@@ -61,6 +66,10 @@ const UserSchema = new Schema({
     type: AddressSchema,
     required: true,
   },
+  phones: {
+    type: [PhoneSchema],
+    required: true,
+  },
 });
 
 interface UserProps extends Document {
@@ -85,6 +94,11 @@ const AddressSchema = createSchema({
   zip: Type.optionalString(),
 });
 
+const PhoneSchema = createSchema({
+  phone: Type.number(),
+  name: Type.optionalString()
+});
+
 const UserSchema = createSchema({
   title: Type.string(),
   author: Type.string(),
@@ -102,6 +116,7 @@ const UserSchema = createSchema({
   m: Type.mixed(),
   otherId: Type.objectId(),
   address: Type.schema().of(AddressSchema),
+  phones: Type.documentsArray().of(PhoneSchema),
 });
 
 const User = typedModel('User', UserSchema);

--- a/README.md
+++ b/README.md
@@ -145,11 +145,17 @@ User.findById('123').then(user => {
   email: Type.string({unique: true, index: true})
 }
 ```
-- `schema`, `object`, `array` types have a method `of` where you must provide a child type
+- `schema`, `object`, `array`, `documentsArray` types have a method `of` where you must provide a child type
 ```ts
 {
   // same as {type: [String], required: true}
   tags: Type.array().of(Type.string())
+}
+```
+```ts
+{
+  // same as {type: [ChildSchema], required: true}
+  tags: Type.documentsArray().of(ChildSchema)
 }
 ```
 - `ref` is a special type for creating references

--- a/__tests__/tests.test.ts
+++ b/__tests__/tests.test.ts
@@ -273,39 +273,6 @@ describe('array', () => {
   });
 });
 
-describe('documentsArray', () => {
-  const CommentSchema = createSchema({
-    content: Type.string(),
-    date: Type.date(),
-  });
-  test('required', () => {
-    expect(Type.documentsArray().of(CommentSchema)).toEqual({
-      type: [CommentSchema],
-      required: true,
-    });
-  });
-  test('required with options', () => {
-    expect(Type.documentsArray({ unique: true }).of(CommentSchema)).toEqual({
-      type: [CommentSchema],
-      required: true,
-      unique: true,
-    });
-  });
-  test('optional', () => {
-    expect(Type.optionalDocumentsArray().of(CommentSchema)).toEqual({
-      type: [CommentSchema],
-    });
-  });
-  test('optional with options', () => {
-    expect(
-      Type.optionalDocumentsArray({ unique: true }).of(CommentSchema)
-    ).toEqual({
-      type: [CommentSchema],
-      unique: true,
-    });
-  });
-});
-
 describe('schema', () => {
   const schema = createSchema({
     foo: Type.string(),

--- a/__tests__/tests.test.ts
+++ b/__tests__/tests.test.ts
@@ -273,6 +273,39 @@ describe('array', () => {
   });
 });
 
+describe('documentsArray', () => {
+  const CommentSchema = createSchema({
+    content: Type.string(),
+    date: Type.date(),
+  });
+  test('required', () => {
+    expect(Type.documentsArray().of(CommentSchema)).toEqual({
+      type: [CommentSchema],
+      required: true,
+    });
+  });
+  test('required with options', () => {
+    expect(Type.documentsArray({ unique: true }).of(CommentSchema)).toEqual({
+      type: [CommentSchema],
+      required: true,
+      unique: true,
+    });
+  });
+  test('optional', () => {
+    expect(Type.optionalDocumentsArray().of(CommentSchema)).toEqual({
+      type: [CommentSchema],
+    });
+  });
+  test('optional with options', () => {
+    expect(
+      Type.optionalDocumentsArray({ unique: true }).of(CommentSchema)
+    ).toEqual({
+      type: [CommentSchema],
+      unique: true,
+    });
+  });
+});
+
 describe('schema', () => {
   const schema = createSchema({
     foo: Type.string(),

--- a/example/example1.ts
+++ b/example/example1.ts
@@ -4,7 +4,7 @@ const AddressSchema = createSchema({
   city: Type.string(),
   country: Type.optionalString(),
   zip: Type.optionalString(),
-});
+}, { _id: false });
 
 const PhoneSchema = createSchema({
   phone: Type.number(),
@@ -28,7 +28,7 @@ const UserSchema = createSchema({
   m: Type.mixed(),
   otherId: Type.objectId(),
   address: Type.schema().of(AddressSchema),
-  phones: Type.documentsArray().of(PhoneSchema),
+  phones: Type.array().of(PhoneSchema),
 });
 
 const User = typedModel('User', UserSchema);
@@ -38,6 +38,6 @@ User.findById('123').then(user => {
   }
 });
 
-type UserDoc = ExtractDoc<typeof User>;
+type UserDoc = ExtractDoc<typeof UserSchema>;
 
 function blockUser(user: UserDoc) {}

--- a/example/example1.ts
+++ b/example/example1.ts
@@ -5,6 +5,11 @@ const AddressSchema = createSchema({
   country: Type.optionalString(),
   zip: Type.optionalString(),
 });
+const PhoneSchema = createSchema({
+  city: Type.string(),
+  name: Type.optionalString(),
+  number: Type.number(),
+});
 
 const UserSchema = createSchema({
   title: Type.string(),
@@ -23,6 +28,7 @@ const UserSchema = createSchema({
   m: Type.mixed(),
   otherId: Type.objectId(),
   address: Type.schema().of(AddressSchema),
+  phones: Type.documentArray().of(PhoneSchema),
 });
 
 const User = typedModel('User', UserSchema);

--- a/example/example1.ts
+++ b/example/example1.ts
@@ -5,10 +5,10 @@ const AddressSchema = createSchema({
   country: Type.optionalString(),
   zip: Type.optionalString(),
 });
+
 const PhoneSchema = createSchema({
-  city: Type.string(),
+  phone: Type.number(),
   name: Type.optionalString(),
-  number: Type.number(),
 });
 
 const UserSchema = createSchema({

--- a/example/example1.ts
+++ b/example/example1.ts
@@ -28,7 +28,7 @@ const UserSchema = createSchema({
   m: Type.mixed(),
   otherId: Type.objectId(),
   address: Type.schema().of(AddressSchema),
-  phones: Type.documentArray().of(PhoneSchema),
+  phones: Type.documentsArray().of(PhoneSchema),
 });
 
 const User = typedModel('User', UserSchema);

--- a/src/Type.ts
+++ b/src/Type.ts
@@ -65,6 +65,15 @@ export const Type = {
       } as any) as ConvertObject<T>[] | null | undefined;
     },
   }),
+  documentArray: (options: SchemaTypeOpts<object> = {}) => ({
+    of<T>(schema: T) {
+      return ({
+        required: true,
+        ...options,
+        type: [schema],
+      } as any) as Types.DocumentArray<Extract<T> & Types.Subdocument>;
+    },
+  }),
   schema: (options: SchemaTypeOpts<object> = {}) => ({
     of<T>(schema: T) {
       return ({

--- a/src/Type.ts
+++ b/src/Type.ts
@@ -65,13 +65,24 @@ export const Type = {
       } as any) as ConvertObject<T>[] | null | undefined;
     },
   }),
-  documentArray: (options: SchemaTypeOpts<object> = {}) => ({
-    of<T>(schema: T) {
+  documentsArray: (options: SchemaTypeOpts<Array<any>> = {}) => ({
+    of<T>(schema: Schema) {
       return ({
         required: true,
         ...options,
         type: [schema],
       } as any) as Types.DocumentArray<Extract<T> & Types.Subdocument>;
+    },
+  }),
+  optionalDocumentsArray: (options: SchemaTypeOpts<Array<any>> = {}) => ({
+    of<T>(schema: Schema) {
+      return ({
+        ...options,
+        type: [schema],
+      } as any) as
+        | Types.DocumentArray<Extract<T> & Types.Subdocument>
+        | null
+        | undefined;
     },
   }),
   schema: (options: SchemaTypeOpts<object> = {}) => ({

--- a/src/Type.ts
+++ b/src/Type.ts
@@ -1,5 +1,10 @@
 import { SchemaTypeOpts, Schema, Types } from 'mongoose';
-import { Extract, ConvertObject, ExtractSchema, IsSchemaType, SubdocumentsArrayWithoutId } from './types';
+import {
+  Extract,
+  ConvertObject,
+  ExtractSchema,
+  ArrayOfElements,
+} from './types';
 
 const createType = <T>(type: any) => (options: SchemaTypeOpts<T> = {}) => {
   return ({
@@ -54,11 +59,7 @@ export const Type = {
         required: true,
         ...options,
         type: [schema],
-      } as any) as IsSchemaType<
-        T,
-        Types.DocumentArray<ConvertObject<T> & Types.Subdocument>,
-        Array<ConvertObject<T>>
-      >;
+      } as any) as ArrayOfElements<T>;
     },
   }),
   optionalArray: (options: SchemaTypeOpts<Array<any>> = {}) => ({
@@ -66,14 +67,7 @@ export const Type = {
       return ({
         ...options,
         type: [schema],
-      } as any) as
-        | IsSchemaType<
-            T,
-            Types.DocumentArray<ConvertObject<T> & Types.Subdocument>, // TODO: id checking as it's done in
-            SubdocumentsArrayWithoutId<ConvertObject<T> & Types.Subdocument>
-          >
-        | null
-        | undefined;
+      } as any) as ArrayOfElements<T> | null | undefined;
     },
   }),
   schema: (options: SchemaTypeOpts<object> = {}) => ({

--- a/src/Type.ts
+++ b/src/Type.ts
@@ -1,5 +1,5 @@
 import { SchemaTypeOpts, Schema, Types } from 'mongoose';
-import { Extract, ConvertObject } from './types';
+import { Extract, ConvertObject, ExtractSchema, IsSchemaType, SubdocumentsArrayWithoutId } from './types';
 
 const createType = <T>(type: any) => (options: SchemaTypeOpts<T> = {}) => {
   return ({
@@ -54,7 +54,11 @@ export const Type = {
         required: true,
         ...options,
         type: [schema],
-      } as any) as ConvertObject<T>[];
+      } as any) as IsSchemaType<
+        T,
+        Types.DocumentArray<ConvertObject<T> & Types.Subdocument>,
+        Array<ConvertObject<T>>
+      >;
     },
   }),
   optionalArray: (options: SchemaTypeOpts<Array<any>> = {}) => ({
@@ -62,25 +66,12 @@ export const Type = {
       return ({
         ...options,
         type: [schema],
-      } as any) as ConvertObject<T>[] | null | undefined;
-    },
-  }),
-  documentsArray: (options: SchemaTypeOpts<Array<any>> = {}) => ({
-    of<T>(schema: Schema) {
-      return ({
-        required: true,
-        ...options,
-        type: [schema],
-      } as any) as Types.DocumentArray<Extract<T> & Types.Subdocument>;
-    },
-  }),
-  optionalDocumentsArray: (options: SchemaTypeOpts<Array<any>> = {}) => ({
-    of<T>(schema: Schema) {
-      return ({
-        ...options,
-        type: [schema],
       } as any) as
-        | Types.DocumentArray<Extract<T> & Types.Subdocument>
+        | IsSchemaType<
+            T,
+            Types.DocumentArray<ConvertObject<T> & Types.Subdocument>, // TODO: id checking as it's done in
+            SubdocumentsArrayWithoutId<ConvertObject<T> & Types.Subdocument>
+          >
         | null
         | undefined;
     },
@@ -91,7 +82,7 @@ export const Type = {
         required: true,
         ...options,
         type: schema,
-      } as any) as Extract<T>;
+      } as any) as ExtractSchema<T>;
     },
   }),
   optionalSchema: (options: SchemaTypeOpts<object> = {}) => ({
@@ -99,7 +90,7 @@ export const Type = {
       return ({
         ...options,
         type: schema,
-      } as any) as Extract<T> | null | undefined;
+      } as any) as ExtractSchema<T> | null | undefined;
     },
   }),
   ref: <T>(schema: T) => ({

--- a/src/createSchema.ts
+++ b/src/createSchema.ts
@@ -1,10 +1,13 @@
 import { SchemaOptions, Schema } from 'mongoose';
 import { ConvertObject } from './types';
 
-type CreateSchema = <T extends { [x: string]: any }>(
+type CreateSchema = <T extends { [x: string]: any }, O extends SchemaOptions>(
   definition?: T,
-  options?: SchemaOptions
-) => Schema & { definition: ConvertObject<T> };
+  options?: O extends SchemaOptions ? SchemaOptions : O
+) => Schema & {
+  definition: ConvertObject<T>;
+  options: O;
+};
 
 export const createSchema: CreateSchema = (definition?, options?) => {
   return new Schema(definition, options) as any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,16 @@
 import { Types, Document } from 'mongoose';
 
 export type Extract<T> = T extends { definition: infer U } ? U : never;
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type ExtractOptions<T> = T extends { options: infer U } ? U : never;
+type DisabledIdOption = { _id: false };
+export type ExtractSchema<T> = Extract<T> &
+  (ExtractOptions<T> extends DisabledIdOption
+    ? Omit<Types.Subdocument, '_id'>
+    : Types.Subdocument);
+export type IsSchemaType<T, IS, NOT> = T extends { definition: any } ? IS : NOT;
+export type SubdocumentsArrayWithoutId<T extends Types.Subdocument> = {[P in keyof Types.DocumentArray<T>]: Omit<T, '_id'>};
 
 type ExcludeBaseType<T> = Exclude<T, string | number | Types.ObjectId>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,12 +5,22 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 type ExtractOptions<T> = T extends { options: infer U } ? U : never;
 type DisabledIdOption = { _id: false };
+type IsSchemaType<T, IS, NOT> = T extends { definition: any } ? IS : NOT;
+type SubdocumentsArrayWithoutId<T extends Types.Subdocument> = {
+  [P in keyof Types.DocumentArray<T>]: Omit<T, '_id'>
+};
+
 export type ExtractSchema<T> = Extract<T> &
   (ExtractOptions<T> extends DisabledIdOption
     ? Omit<Types.Subdocument, '_id'>
     : Types.Subdocument);
-export type IsSchemaType<T, IS, NOT> = T extends { definition: any } ? IS : NOT;
-export type SubdocumentsArrayWithoutId<T extends Types.Subdocument> = {[P in keyof Types.DocumentArray<T>]: Omit<T, '_id'>};
+export type ArrayOfElements<T> = IsSchemaType<
+  T,
+  ExtractOptions<T> extends DisabledIdOption
+    ? SubdocumentsArrayWithoutId<Extract<T> & Types.Subdocument>
+    : Types.DocumentArray<Extract<T> & Types.Subdocument>,
+  Array<T>
+>;
 
 type ExcludeBaseType<T> = Exclude<T, string | number | Types.ObjectId>;
 


### PR DESCRIPTION
Take a look on documentArray type for array of subdocuments. It works similar to standard array, but let us use additional methods like id to get subdocument directly by it's id, and replace some of them like push to automatically add subdocument and save whole document. For more info check mongoose docs: [https://mongoosejs.com/docs/subdocs.html](url)

This might be useful in editing document, where new subdocument need to be added - in this case standard array require item to be exact type of subschema, which isn't correct behavior.