### PR TITLE
Filter type by condition specified in callback function

### DIFF
--- a/src/types/_shared.ts
+++ b/src/types/_shared.ts
@@ -20,6 +20,14 @@ export interface SubDocument extends Types.Subdocument {}
 // subDocument array
 export interface SubDocumentArray<T extends SubDocument>
   extends Types.DocumentArray<T> {
+  filter<S extends T>(
+    callbackfn: (
+      value: T,
+      index: number,
+      array: SubDocumentArray<T>
+    ) => value is S,
+    thisArg?: any
+  ): S[] & SubDocumentArray<S>;
   filter(
     callbackfn: (
       value: T,
@@ -34,6 +42,14 @@ export interface SubDocumentArrayNoId<T extends SubDocumentNoId>
   create(obj: any): T;
   inspect(): T[];
   toObject(options?: any): T[];
+  filter<S extends T>(
+    callbackfn: (
+      value: T,
+      index: number,
+      array: SubDocumentArrayNoId<T>
+    ) => value is S,
+    thisArg?: any
+  ): S[] & SubDocumentArrayNoId<S>;
   filter(
     callbackfn: (
       value: T,


### PR DESCRIPTION
I was trying to filter out items by type guard and I notice that filter is implemented just in the way that the returned SubDocumentArray has not any information about doc's fields. So I add implementation for `filter` which returned type is based on the condition specified in callback function.

But, I'm not sure about the `S[] & SubDocumentArrayNoId<S>` in return type. It is right or it should return just `S[]`?

Thanks for any advice.