### PR TITLE
Add support for Connection in typedModel()

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,34 @@ const u = await User.findOne({});
 if (u) u.name;
 ```
 
+### Connection model
+
+If you are using `mongoose.createConnection(...)`, you can pass a `<mongoose.Connection>` as the 6th parameter of `typedModel`. Then the module will be added to that connection instead.  
+(**Note:** If using the `connection` parameter, the `skipInit` parameter will not be used)
+
+```ts
+import mongoose from 'mongoose'
+import { typedModel } from 'ts-mongoose'
+
+const UserSchema = createSchema({
+  name: Type.string({ required: true }),
+  age: Type.number({ required: true }),
+});
+
+const connection = mongoose.createConnection(`mongodb://localhost:27017/test`, {...})
+
+const User = typedModel('User', UserSchema, undefined, undefined, undefined, connection);
+
+
+console.log(connection.modelNames()) // Prints: [ 'User' ]
+
+// Now you can use the model directly
+User.find({ name: 'Peter' })
+// Or through the connection
+connection.model('User').find({ name: 'Peter' })
+
+```
+
 ### TODO
 
 - support types: Map

--- a/__tests__/tests.test.ts
+++ b/__tests__/tests.test.ts
@@ -1,5 +1,5 @@
 import { createSchema, Type, typedModel } from '../src';
-import { Schema } from 'mongoose';
+import mongoose, { Schema, Connection } from 'mongoose';
 
 describe('string', () => {
   test('required', () => {
@@ -410,5 +410,21 @@ describe('typedModel - statics', () => {
       },
     });
     expect(typeof CommentModel.countLetters).toBe('function');
+  });
+});
+
+describe('typedModel - mongoose.createConnection', () => {
+  const connection = new mongoose.Connection(mongoose) // Created like this for offline use
+  const CommentSchema = createSchema({
+    content: Type.string(),
+    date: Type.date(),
+  });
+  const CommentModel = typedModel('cm', CommentSchema, undefined, undefined, {}, connection);
+
+  test('returns correct modelName', () => {
+    expect(CommentModel.modelName).toBe('cm');
+  });
+  test('connection contains correct model', () => {
+    expect(connection.modelNames()).toContain('cm');
   });
 });

--- a/__tests__/tests.test.ts
+++ b/__tests__/tests.test.ts
@@ -1,5 +1,5 @@
 import { createSchema, Type, typedModel } from '../src';
-import mongoose, { Schema, Connection } from 'mongoose';
+import mongoose, { Schema } from 'mongoose';
 
 describe('string', () => {
   test('required', () => {

--- a/__tests__/tests.test.ts
+++ b/__tests__/tests.test.ts
@@ -411,6 +411,14 @@ describe('typedModel - statics', () => {
     });
     expect(typeof CommentModel.countLetters).toBe('function');
   });
+  test('should return Model without a static function', () => {
+    const CommentSchemaNoStatic = createSchema({
+      content: Type.string(),
+      date: Type.date(),
+    });
+    const CommentModelNoStatic = typedModel('cmns', CommentSchemaNoStatic);
+    expect(typeof CommentModelNoStatic.countLetters).toBe('undefined');
+  });
 });
 
 describe('typedModel - mongoose.createConnection', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-mongoose",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "",
   "main": "index.js",
   "module": "es/index.js",
@@ -25,11 +25,11 @@
   },
   "homepage": "https://github.com/BetterCallSky/ts-mongoose#readme",
   "devDependencies": {
+    "@types/jest": "^24.0.19",
     "@types/mongoose": "^5.5.21",
     "@types/node": "^12.7.12",
-    "mongoose": "^5.7.5",
-    "@types/jest": "^24.0.19",
     "jest": "^24.9.0",
+    "mongoose": "^5.7.5",
     "prettier": "^1.18.2",
     "ts-jest": "^24.1.0",
     "typescript": "^3.6.3"

--- a/src/typedModel.ts
+++ b/src/typedModel.ts
@@ -1,4 +1,4 @@
-import { Schema, Document, Model, model } from 'mongoose';
+import { Schema, Document, Model, model, Connection } from 'mongoose';
 import { Extract } from './types';
 
 export function typedModel<
@@ -9,8 +9,10 @@ export function typedModel<
   schema?: T,
   collection?: string,
   skipInit?: boolean,
-  statics?: S & ThisType<Model<Document & Extract<T>>>
+  statics?: S & ThisType<Model<Document & Extract<T>>>,
+  connection?: Connection
 ): Model<Document & Extract<T>> & S {
   if (schema && statics) schema.statics = statics;
+  if (connection) return connection.model(name, schema, collection) as any;
   return model(name, schema, collection, skipInit) as any;
 }


### PR DESCRIPTION
## Reason for PR
I am currently using `mongoose.createConnection(...)` in a Typescript project. And since this (awesome) package only supports to use the config in `mongoose`, I added support for `Connection` too.
This will return the `Model` and add it to the `Connection` passed into `typedModel()`.

I also noticed issue #1 who also wanted this feature.

## Commits
#### 759d6d6be2dce5bed169f83c6ad713346b1fb140
Added the optional `connection` parameter. If passed it will return a Model made by `mongoose.createConnection` instead.

#### 85b169403262136deb4ad7408f4ba59fe47845f6
Added tests for the new `connection` parameter.

#### 6eee38a2d9fea82e5e0e581b0e0610cb8642669a
Updated the README to include a description and example of it.

#### 924b835d820f7785c6f426ec31947fbaabf5d33d
Added a test under `typedModel - statics` so the coverage on `typedModel.ts` is 100%.