### PR TITLE
Add support for Type.buffer()

### DIFF
--- a/__tests__/tests.test.ts
+++ b/__tests__/tests.test.ts
@@ -223,7 +223,32 @@ describe('decimal128', () => {
     });
   });
 });
-
+describe('buffer', () => {
+  test('required', () => {
+    expect(Type.buffer({ required: true })).toEqual({
+      type: Schema.Types.Buffer,
+      required: true,
+    });
+  });
+  test('required with options', () => {
+    expect(Type.buffer({ required: true, unique: true })).toEqual({
+      type: Schema.Types.Buffer,
+      required: true,
+      unique: true,
+    });
+  });
+  test('optional', () => {
+    expect(Type.buffer()).toEqual({
+      type: Schema.Types.Buffer
+    });
+  });
+  test('optional with options', () => {
+    expect(Type.buffer({ unique: true })).toEqual({
+      type: Schema.Types.Buffer,
+      unique: true,
+    });
+  });
+});
 describe('object', () => {
   test('required', () => {
     expect(
@@ -405,7 +430,7 @@ describe('typedModel - statics', () => {
       date: Type.date(),
     });
     const CommentModel = typedModel('cm', CommentSchema, undefined, undefined, {
-      countLetters: function(name: string, bonus?: number): number {
+      countLetters: function (name: string, bonus?: number): number {
         return name.length + (bonus ? bonus : 0);
       },
     });

--- a/src/Type.ts
+++ b/src/Type.ts
@@ -28,6 +28,7 @@ export const Type = {
   objectId: createType<Types.ObjectId>(Schema.Types.ObjectId),
   string: createType<string>(String),
   decimal128: createType<Types.Decimal128>(Schema.Types.Decimal128),
+  buffer: createType<Types.Buffer>(Schema.Types.Buffer),
   object: <O extends TypeOptions<object>>(options?: O) => ({
     of<T extends object>(schema: T) {
       return ({
@@ -60,8 +61,8 @@ export const Type = {
       } as unknown) as
         | T
         | (T extends Record<OptionalField, any>
-            ? Optional<TSchema[DefinitionField]>
-            : TSchema[DefinitionField]);
+          ? Optional<TSchema[DefinitionField]>
+          : TSchema[DefinitionField]);
     },
   }),
 };


### PR DESCRIPTION
Added support for Type.buffer() to support mongoose.buffer data type.  
Updated __tests__ based upon testing model for primitives like string, number, etc. 